### PR TITLE
Allow Symfony finder to go beyond 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php":                              ">=5.3.2",
         "doctrine/dbal":                    "~2.1",
-        "symfony/finder":                   "2.1.*",
+        "symfony/finder":                   "~2.1",
         "knplabs/console-service-provider": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Allow Symfony finder to go beyond 2.1
